### PR TITLE
Change use of img to image_tag

### DIFF
--- a/app/views/pages/_navbar.html.erb
+++ b/app/views/pages/_navbar.html.erb
@@ -1,18 +1,18 @@
 <nav class="nav-bar">
-  <img src="/assets/studiobookcropped.png" alt="studiobook" class="nav-logo">
-    <ul class="nav-links">
-      <li><a href="#" class="active">Book Studio</a></li>
-      <li><%=link_to 'Top rooms', rooms_path%></li>
-      <%# <li><a href="">Support</a></li> %>
-    </ul>
-    <div class="nav-buttons d-flex">
-    <% if user_signed_in? %>
-    <%= link_to "List your studio here", new_studio_path, class: "nav-list-btn" %>
-    <%= link_to 'Sign Out', destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?'}, class: "nav-sign-out-btn" %>
-    <% else %>
-    <%= link_to "List your studio here", new_studio_path, class: "nav-list-btn" %>
-    <%= link_to "Login", new_user_session_path, class: "nav-login-btn" %>
-    <a href="#" class="nav-register-btn">Register Now</a>
-    <% end %>
-    </div>
+  <%= image_tag "studiobookcropped.png" alt:"studiobook" class:"nav-logo" %>
+  <ul class="nav-links">
+    <li><a href="#" class="active">Book Studio</a></li>
+    <li><%=link_to 'Top rooms', rooms_path%></li>
+    <%# <li><a href="">Support</a></li> %>
+  </ul>
+  <div class="nav-buttons d-flex">
+  <% if user_signed_in? %>
+  <%= link_to "List your studio here", new_studio_path, class: "nav-list-btn" %>
+  <%= link_to 'Sign Out', destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?'}, class: "nav-sign-out-btn" %>
+  <% else %>
+  <%= link_to "List your studio here", new_studio_path, class: "nav-list-btn" %>
+  <%= link_to "Login", new_user_session_path, class: "nav-login-btn" %>
+  <a href="#" class="nav-register-btn">Register Now</a>
+  <% end %>
+  </div>
 </nav>


### PR DESCRIPTION
# Background
Images in production aren't working. This might be because images in the codebase are using `<img src="...">` instead of `image_tag` (which uses the rails asset pipeline to look for the correct images).

# Approach
Change the navbar logo to use `image_tag`. If this works, then can change all other instances of  `<img src="...">` to `image_tag`

Can see that the changes did not cause development logo to break
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/19161092/192079109-55daf1f5-f383-485a-a697-4ad941beff12.png">


# Testing instructions
Merge, and deploy to heroku. See that the navbar logo appears in production
